### PR TITLE
Allow arbitrary database type derived from .platform.app, fixes #13

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -62,14 +62,14 @@ pre_install_actions:
         version: {{ regexReplaceAll "^.*:" $dbtype "" }}
     
       docroot: {{ dig "web" "locations" "/" "root" "notfound" .platformapp }}
-      {{ if eq .platformapp.build.flavor "composer" }}
       hooks:
         post-start:
+      {{ if eq .platformapp.build.flavor "composer" }}
         - composer: install
       {{ end }}
 
       {{ if .platformapp.hooks.deploy }}
-        - exec: {{ trimAll "\n" .platformapp.hooks.deploy | splitList "\n"  | join `&&` }}
+        - exec: '{{ trimAll "\n" .platformapp.hooks.deploy | replace "\n\n" "\n" | splitList "\n"  | join ` && ` }}'
       {{ end }}
       EOF
 

--- a/install.yaml
+++ b/install.yaml
@@ -33,7 +33,10 @@ pre_install_actions:
         if [ -z "${current_db_version}" ]; then
           echo "something went wrong, current_db_version is empty" && false
         fi
-        export upstream_db="{{ regexReplaceAll "oracle-" (regexReplaceAll ":.*$" .services.dbmysql.type "") "" }}:{{ regexReplaceAll "^.*:" .services.dbmysql.type "" }}"
+        {{ $dbheader := index (split ":" .platformapp.relationships.database) "_0" }} 
+        {{ $dbtype := get (get .services $dbheader) "type" }}
+        # echo "dbheader={{$dbheader}} dbtype={{$dbtype}} "
+        export upstream_db="{{ regexReplaceAll "oracle-" (regexReplaceAll ":.*$" $dbtype "") "" }}:{{ regexReplaceAll "^.*:" $dbtype "" }}"
         echo "Current db is ${current_db_version/_/:} (${current_db_version})"
         echo "New db is ${upstream_db}"
         if [ "${current_db_version/_/:}" != "${upstream_db}" ]; then
@@ -50,10 +53,13 @@ pre_install_actions:
       cat <<EOF >.ddev/config.platformsh.yaml
       # #ddev-generated
       # Generated configuration based on platform.sh project configuration
+      {{ $dbheader := index (split ":" .platformapp.relationships.database) "_0" }} 
+      {{ $dbtype := get (get .services $dbheader) "type" }}
+    
       php_version: {{ trimPrefix "php:" .platformapp.type }}
       database:
-        type: {{ regexReplaceAll "oracle-" (regexReplaceAll ":.*$" .services.dbmysql.type "") "" }}
-        version: {{ regexReplaceAll "^.*:" .services.dbmysql.type "" }}
+        type: {{ regexReplaceAll "oracle-" (regexReplaceAll ":.*$" $dbtype "") "" }}
+        version: {{ regexReplaceAll "^.*:" $dbtype "" }}
     
       docroot: {{ dig "web" "locations" "/" "root" "notfound" .platformapp }}
       {{ if eq .platformapp.build.flavor "composer" }}

--- a/install.yaml
+++ b/install.yaml
@@ -34,7 +34,7 @@ pre_install_actions:
           echo "something went wrong, current_db_version is empty" && false
         fi
         {{ $dbheader := index (split ":" .platformapp.relationships.database) "_0" }} 
-        {{ $dbtype := get (get .services $dbheader) "type" }}
+        {{ $dbtype := replace "postgresql" "postgres" (get (get .services $dbheader) "type") }}
         # echo "dbheader={{$dbheader}} dbtype={{$dbtype}} "
         export upstream_db="{{ regexReplaceAll "oracle-" (regexReplaceAll ":.*$" $dbtype "") "" }}:{{ regexReplaceAll "^.*:" $dbtype "" }}"
         echo "Current db is ${current_db_version/_/:} (${current_db_version})"
@@ -54,7 +54,7 @@ pre_install_actions:
       # #ddev-generated
       # Generated configuration based on platform.sh project configuration
       {{ $dbheader := index (split ":" .platformapp.relationships.database) "_0" }} 
-      {{ $dbtype := get (get .services $dbheader) "type" }}
+      {{ $dbtype := replace "postgresql" "postgres" (get (get .services $dbheader) "type") }}
     
       php_version: {{ trimPrefix "php:" .platformapp.type }}
       database:


### PR DESCRIPTION
* #13 

It turns out that services.yml/.platform.app can use any random value for the db section; it has to be derived from the arbitrary value used in .platform.app. See #13 