### PR TITLE
Always self:update platform tool if possible, fixes #31

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -169,6 +169,8 @@ pre_install_actions:
     
       hooks:
         post-start:
+        - platform self:update -qy --no-major || true
+
       {{ if eq .platformapp.build.flavor "composer" }}
         - composer: install
       {{ end }}
@@ -179,14 +181,14 @@ pre_install_actions:
         - exec: |
       {{ indent 6 $noblanks }}
       {{ end }}
-    
+
       {{ if .platformapp.hooks.deploy }}
         # platformsh deploy hooks
       {{ $noblanks := regexReplaceAll "\n\n*" .platformapp.hooks.deploy "\n" }}
         - exec: |
       {{ indent 6 $noblanks }}
       {{ end }}
-    
+
       {{ if .platformapp.hooks.post_deploy }}
         # platformsh post_deploy hooks
       {{ $noblanks := regexReplaceAll "\n\n*" .platformapp.hooks.post_deploy "\n" }}

--- a/install.yaml
+++ b/install.yaml
@@ -169,7 +169,7 @@ pre_install_actions:
     
       hooks:
         post-start:
-        - platform self:update -qy --no-major || true
+        - exec: platform self:update -qy --no-major || true
 
       {{ if eq .platformapp.build.flavor "composer" }}
         - composer: install

--- a/web-build/Dockerfile.platformsh
+++ b/web-build/Dockerfile.platformsh
@@ -1,5 +1,2 @@
 #ddev-generated
-# Get latest platform tool at time of project creation
-# platform self:update fails if there are no updates, and also fails if no internet
-RUN platform self:update -y --no-major || true
 RUN ln -sf /var/www/html /app


### PR DESCRIPTION
* #31 

In the Dockerfile, the `platform self:update` would be cached, no perhaps never updated. Move to post-start hook.