### PR TITLE
Put Platform token in global config where it won't get committed, fixes #39

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -21,7 +21,7 @@ pre_install_actions:
       read token
       # Put the token into the global web environment
       ddev config global --web-environment-add PLATFORMSH_CLI_TOKEN=${token}
-      echo "PLATFORMSH_CLI_TOKEN set for project"
+      echo "PLATFORMSH_CLI_TOKEN set globally"
     fi
 
   # Get PLATFORM_PROJECT from user if we don't have it yet

--- a/install.yaml
+++ b/install.yaml
@@ -19,8 +19,8 @@ pre_install_actions:
     #ddev-nodisplay
     if !( {{ contains "PLATFORMSH_CLI_TOKEN" (list .DdevGlobalConfig.web_environment | toString) }} || {{ contains "PLATFORMSH_CLI_TOKEN" (list .DdevProjectConfig.web_environment | toString) }} ); then
       read token
-      # Put the token in to the project web environment
-      ddev config --web-environment-add PLATFORMSH_CLI_TOKEN=${token}
+      # Put the token into the global web environment
+      ddev config global --web-environment-add PLATFORMSH_CLI_TOKEN=${token}
       echo "PLATFORMSH_CLI_TOKEN set for project"
     fi
 


### PR DESCRIPTION
* #39 

The Platform token was going into the project config, but it's better for it to be in global config.