### PR TITLE
Add memcached as supported cache type

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -218,6 +218,10 @@ post_install_actions:
   echo "Running 'ddev get drud/ddev-redis'"
   ddev get drud/ddev-redis
   {{ end }}
+  {{ if and .services.cache.type (hasPrefix "memcached" .services.cache.type) }}
+  echo "Running 'ddev get drud/ddev-memcached'"
+  ddev get drud/ddev-memcached
+  {{ end }}
   {{ if and .services.search.type (hasPrefix "elasticsearch" .services.search.type) }}
   echo "Running 'ddev get drud/ddev-elasticsearch'"
   ddev get drud/ddev-elasticsearch


### PR DESCRIPTION
This adds memcached just the same as redis is supported.

I don't have an example that uses this right now, so tests are likely irrelevant. 