### PR TITLE
Generate key-less SSH certificate on start

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -170,6 +170,7 @@ pre_install_actions:
       hooks:
         post-start:
         - exec: platform self:update -qy --no-major || true
+        - exec: '[ ! -z "$PLATFORMSH_CLI_TOKEN" ] && platform ssh-cert:load  -y'
 
       {{ if eq .platformapp.build.flavor "composer" }}
         - composer: install


### PR DESCRIPTION
This also takes care of adding the proper information to ~/.ssh/config.