### PR TITLE
Fix potential errors when trying to cert:load

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -252,8 +252,7 @@ post_install_actions:
   hooks:
     post-start:
     - exec: platform self:update -qy --no-major || true
-    - exec: '[ ! -z "$PLATFORMSH_CLI_TOKEN" ] && platform ssh-cert:load  -y'
-  
+    - exec: '[ ! -z "${PLATFORMSH_CLI_TOKEN:-}" ] && (platform ssh-cert:load  -y || true)'
   {{ if eq .platformapp.build.flavor "composer" }}
     - composer: install
   {{ end }}


### PR DESCRIPTION
I was using this line and found two issues:
- exec is run with set +u so if the env var is not there it fails, now it wont
- and also, if the test of the token (without the above error) is false, it also provides an error exit code, so added `|| true` in the end as well.