### PR TITLE
Update wordpress-composer test; now php 8.1

### DIFF
--- a/tests/wordpress-composer.bats
+++ b/tests/wordpress-composer.bats
@@ -20,7 +20,7 @@ teardown() {
     run ddev exec 'echo $PLATFORM_RELATIONSHIPS | base64 -d | jq -r ".database[0].username"'
     assert_output "db"
     run ddev exec "php --version | awk 'NR==1 { sub(/\.[0-9]+$/, \"\", \$2); print \$2 }'"
-    assert_output "7.4"
+    assert_output "8.1"
     run ddev exec ls wordpress/wp-config.php
     assert_output "wordpress/wp-config.php"
     ddev describe -j >describe.json


### PR DESCRIPTION
Tests broke because wordpress-composer template now does php 8.1