### PR TITLE
PLATFORM_ROUTES should properly expand the primary URL, fixes #47

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -132,12 +132,12 @@ post_install_actions:
   #ddev-description:Installing dependencies and generating needed environment variables
 
   # set -x
-  platform_routes=$(cat <<-"ENDROUTES"
+  platform_routes=$(cat <<-ENDROUTES
   {
-  "${DDEV_PRIMARY_URL}": {
+  "${DDEV_PRIMARY_URL}/": {
     "primary": true,
     "id": null,
-    "production_url": "${DDEV_PRIMARY_URL}",
+    "production_url": "${DDEV_PRIMARY_URL}/",
     "attributes": {},
     "upstream": "drupal",
     "type": "upstream",

--- a/tests/drupal9.bats
+++ b/tests/drupal9.bats
@@ -26,6 +26,8 @@ teardown() {
     run  jq -r .raw.docroot <describe.json
     assert_output "web"
 
+    assert_equal $(ddev exec 'echo $PLATFORM_ROUTES | base64 -d | jq -r "keys[0]"') "https://${PROJNAME}.ddev.site/"
+    assert_equal $(ddev exec 'echo $PLATFORM_ROUTES | base64 -d | jq -r .[].production_url') "https://${PROJNAME}.ddev.site/"
     ddev exec 'echo $PLATFORM_RELATIONSHIPS | base64 -d' >relationships.json
     echo "# PLATFORM_RELATIONSHIPS=$(cat relationships.json)" >&3
 


### PR DESCRIPTION
* #47 

This PR just
* Changes to expand PLATFORM_ROUTES (a single element) correctly
* Adds a test to make sure that happens

This may not be enough for #47 - please let me know if we need to go beyond having a fixed single route at this time.

test:
```
ddev get https://github.com/rfay/ddev-platformsh/tarball/20221208_platform_routes
ddev restart
ddev exec 'echo $PLATFORM_ROUTES | base64 -d | jq'
```

