### PR TITLE
Support PLATFORM_CACHE_DIR, fixes #69

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -244,6 +244,7 @@ post_install_actions:
   - "PLATFORM_PROJECT_ENTROPY=${PLATFORM_PROJECT_ENTROPY}"
   # Consider commit hash for PLATFORM_TREE_ID
   - "PLATFORM_TREE_ID=2dc356f2fea13ef683f9adc5fc5bd28e05ad992a"
+  - "PLATFORM_CACHE_DIR=/mnt/ddev-global-cache/ddev-platformsh/${DDEV_PROJECT}"
   - "PLATFORM_DIR=/var/www/html"
   - "PLATFORM_ROUTES=${PLATFORM_ROUTES}"
   - "PLATFORM_VARIABLES=e30="
@@ -261,6 +262,7 @@ post_install_actions:
   hooks:
     post-start:
     - exec: platform self:update -qy --no-major || true
+    - exec: mkdir -p ${PLATFORM_CACHE_DIR} || true
     - exec: '[ ! -z "${PLATFORMSH_CLI_TOKEN:-}" ] && (platform ssh-cert:load  -y || true)'
   {{ if eq .platformapp.build.flavor "composer" }}
     - composer: install

--- a/tests/drupal9.bats
+++ b/tests/drupal9.bats
@@ -19,6 +19,9 @@ teardown() {
     assert_output "mariadb:10.4"
     run ddev exec "php --version | awk 'NR==1 { sub(/\.[0-9]+$/, \"\", \$2); print \$2 }'"
     assert_output "8.0"
+
+    ddev exec 'touch ${PLATFORM_CACHE_DIR}/junk.txt'
+
     ddev describe -j >describe.json
     run  jq -r .raw.docroot <describe.json
     assert_output "web"


### PR DESCRIPTION
* #69 

* set $PLATFORM_CACHE_DIR
* create nonvolatile $PLATFORM_CACHE_DIR in ddev-global-cache
* Add test to make sure we can access it.