### PR TITLE
PATH addition not working, add it in platform-environment.sh

### DIFF
--- a/homeadditions/.bashrc.d/platformsh-environment.sh
+++ b/homeadditions/.bashrc.d/platformsh-environment.sh
@@ -1,5 +1,7 @@
 #ddev-generated
 
+export PATH=$PATH:$PLATFORM_APP_DIR/.global/bin
+
 for item in .global/environment .environment; do
   if [ -f "${item}" ]; then
     . "${item}"

--- a/install.yaml
+++ b/install.yaml
@@ -247,7 +247,6 @@ post_install_actions:
   - "PLATFORM_DIR=/var/www/html"
   - "PLATFORM_ROUTES=${PLATFORM_ROUTES}"
   - "PLATFORM_VARIABLES=e30="
-  - "PATH=$PATH:/var/www/html/.global/bin"
   {{ if .platformapp.variables.env }}
   {{ range $key, $value := .platformapp.variables.env }}
   - "{{$key}}={{$value}}"{{ end }}{{ end }}


### PR DESCRIPTION
`/var/www/html/.global/bin` was not correctly set in the `$PATH` using regular `web_environment` section.
Fix #74 