### PR TITLE
Add a step to check for required tools, fixes #46

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -19,6 +19,20 @@ pre_install_actions:
     #ddev-description:Checking DDEV version
     (ddev debug capabilities | grep migrate-database >/dev/null) || (echo "Please upgrade DDEV to v1.21.1+ for appropriate capabilities" && false)
 
+  - |
+    #ddev-nodisplay
+    #ddev-description:Check for required tools base64, jq, perl
+    needed=""
+    for item in base64 jq perl ; do
+      if ! command -v $item >/dev/null; then
+        needed="${needed} ${item}"
+      fi
+    done
+    if [ "${needed}" != "" ]; then
+      echo "Please install ${needed} on the host computer to use this add-on.";
+      exit 1;
+    fi
+
   # Get PLATFORMSH_CLI_TOKEN from user if we don't have it yet
   - |
     #ddev-nodisplay


### PR DESCRIPTION
* #46 

Current known local-install tools are base64, jq, perl;; this checks for them and warns that they're needed. 

We'd like to get rid of external dependencies, but this will do for now. 

* https://github.com/drud/ddev/pull/4441 also improves this experience, by not showing a whole wall of text by default when a step fails.